### PR TITLE
ci: update upload-artifact to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           name: g64drive-windows-amd64
           path: g64drive.exe
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true
@@ -107,7 +107,7 @@ jobs:
           name: g64drive-mac-amd64
           path: g64drive
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: 1.18.x
       - name: Install dependencies
@@ -81,7 +81,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: 1.18.x
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
@@ -79,7 +79,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: /usr/local/lib/pkgconfig:/usr/lib/pkgconfig
       - name: Upload Linux binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: g64drive-linux-amd64
           path: g64drive
@@ -62,7 +62,7 @@ jobs:
           WIN_CERTIFICATE_KEY: ${{ secrets.WIN_CERTIFICATE_KEY }}
           WIN_CERTIFICATE_PUB: ${{ secrets.WIN_CERTIFICATE_PUB }}
       - name: Upload Windows binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: g64drive-windows-amd64
           path: g64drive.exe
@@ -102,7 +102,7 @@ jobs:
           go build -v -ldflags '-s -w'
           zip -9 g64drive-mac-amd64.zip g64drive
       - name: Upload Linux binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: g64drive-mac-amd64
           path: g64drive


### PR DESCRIPTION
CI Workflows currently fail because of usage of deprecated actions. Update them to latest version to make the CI green again.